### PR TITLE
Ensure no function calls after one context is cancelled

### DIFF
--- a/singleflight.go
+++ b/singleflight.go
@@ -17,7 +17,7 @@ import (
 // which units of work can be executed with duplicate suppression.
 type Group[K comparable, V any] struct {
 	calls map[K]*call[V] // lazily initialized
-	mu    sync.Mutex       // protects calls
+	mu    sync.Mutex     // protects calls
 }
 
 // Do executes and returns the results of the given function, making sure that
@@ -76,9 +76,9 @@ func (g *Group[K, V]) wait(ctx context.Context, key K, c *call[V]) (v V, shared 
 	c.counter--
 	if c.counter == 0 {
 		c.cancel()
-	}
-	if !c.forgotten {
-		delete(g.calls, key)
+		if !c.forgotten {
+			delete(g.calls, key)
+		}
 	}
 	g.mu.Unlock()
 	return v, c.shared, err

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -201,6 +201,58 @@ func TestDo_cancelContextSecond(t *testing.T) {
 	}
 }
 
+func TestDo_callDoAfterCancellation(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+
+	var g singleflight.Group[string, string]
+
+	callCounter := new(atomic.Uint64)
+	fn := func(_ context.Context) (string, error) {
+		callCounter.Add(1)
+		select {
+		case <-time.After(time.Second):
+		case <-done:
+		}
+		return "", nil
+	}
+
+	go func() {
+		// keep the function call active for long period (1 second)
+		if _, _, err := g.Do(context.Background(), "key", fn); err != nil {
+			panic(err)
+		}
+	}()
+
+	{ // make another call that is canceled shortly (100 milliseconds)
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		_, _, err := g.Do(ctx, "key", fn)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatal(err)
+		}
+	}
+
+	want := uint64(1)
+
+	if got := callCounter.Load(); got != want {
+		t.Errorf("got call counter %v, want %v", got, want)
+	}
+
+	{ // make another call after the previous call cancellation
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		_, _, err := g.Do(ctx, "key", fn)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatal(err)
+		}
+	}
+
+	if got := callCounter.Load(); got != want {
+		t.Errorf("got call counter %v, want %v", got, want)
+	}
+}
+
 func TestForget(t *testing.T) {
 	done := make(chan struct{})
 	defer close(done)


### PR DESCRIPTION
This PR fixes the issue described in #4. It correctly removes the call value from the map only if the counter is at the 0 value.
A regression unit test TestDo_callDoAfterCancellation is made to validate the fix.

fixes #4 