### PR TITLE
add goroutine leak detector to tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module resenje.org/singleflight
 
 go 1.18
+
+require go.uber.org/goleak v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -19,9 +19,14 @@ import (
 	"time"
 
 	"resenje.org/singleflight"
+
+	"go.uber.org/goleak"
 )
 
 func TestDo(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	var g singleflight.Group[string, string]
 
 	want := "val"
@@ -40,6 +45,9 @@ func TestDo(t *testing.T) {
 }
 
 func TestDo_concurrentAccess(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	var g singleflight.Group[string, string]
 
 	want := "val"
@@ -68,6 +76,9 @@ func TestDo_concurrentAccess(t *testing.T) {
 }
 
 func TestDo_error(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	var g singleflight.Group[string, string]
 	wantErr := errors.New("test error")
 	got, _, err := g.Do(context.Background(), "key", func(_ context.Context) (string, error) {
@@ -82,6 +93,9 @@ func TestDo_error(t *testing.T) {
 }
 
 func TestDo_multipleCalls(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	var g singleflight.Group[string, string]
 
 	want := "val"
@@ -123,6 +137,9 @@ func TestDo_multipleCalls(t *testing.T) {
 }
 
 func TestDo_callRemoval(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	var g singleflight.Group[string, string]
 
 	wantPrefix := "val"
@@ -156,6 +173,9 @@ func TestDo_callRemoval(t *testing.T) {
 }
 
 func TestDo_cancelContext(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	done := make(chan struct{})
 	defer close(done)
 
@@ -190,6 +210,9 @@ func TestDo_cancelContext(t *testing.T) {
 }
 
 func TestDo_cancelContextSecond(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	done := make(chan struct{})
 	defer close(done)
 
@@ -230,6 +253,9 @@ func TestDo_cancelContextSecond(t *testing.T) {
 }
 
 func TestDo_callDoAfterCancellation(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	done := make(chan struct{})
 	defer close(done)
 
@@ -282,6 +308,9 @@ func TestDo_callDoAfterCancellation(t *testing.T) {
 }
 
 func TestForget(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	done := make(chan struct{})
 	defer close(done)
 
@@ -324,6 +353,9 @@ func TestForget(t *testing.T) {
 }
 
 func TestDo_multipleCallsCanceled(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	const n = 5
 
 	for lastCall := 0; lastCall < n; lastCall++ {
@@ -422,6 +454,9 @@ func TestDo_multipleCallsCanceled(t *testing.T) {
 }
 
 func TestDo_preserveContextValues(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	var g singleflight.Group[string, any]
 
 	type KeyType string


### PR DESCRIPTION
this is purely a safety measure. if these leak detectors fail it could mean a real leak in the code or either a badly designed test that doesn't wait till all goroutines finish before it ends.

 i am not sure how to _not_ pollute the main `go.mod` with this dev- only dependency.