### PR TITLE
fix duplicate key deletion when forget called

### DIFF
--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -382,7 +382,7 @@ func TestForgetMisbehaving(t *testing.T) {
 
 	firstCh := make(chan struct{})
 	go func() {
-		g.Do(context.Background(), "key", func(ctx context.Context) (i int, e error) {
+		_, _, _ = g.Do(context.Background(), "key", func(ctx context.Context) (i int, e error) {
 			firstStarted.Done()
 			<-firstCh
 			firstFinished.Done()
@@ -400,7 +400,7 @@ func TestForgetMisbehaving(t *testing.T) {
 	secondCh := make(chan struct{})
 	secondRunning := make(chan struct{})
 	go func() {
-		g.Do(context.Background(), "key", func(ctx context.Context) (i int, e error) {
+		_, _, _ = g.Do(context.Background(), "key", func(ctx context.Context) (i int, e error) {
 			atomic.AddInt32(&secondStarted, 1)
 			// Notify that we started
 			secondCh <- struct{}{}

--- a/singleflight_test.go
+++ b/singleflight_test.go
@@ -370,6 +370,76 @@ func TestForget(t *testing.T) {
 	}
 }
 
+// Test that singleflight behaves correctly after Forget called.
+// See https://github.com/golang/go/issues/31420
+func TestForgetMisbehaving(t *testing.T) {
+	var g singleflight.Group[string, int]
+
+	var firstStarted, firstFinished sync.WaitGroup
+
+	firstStarted.Add(1)
+	firstFinished.Add(1)
+
+	firstCh := make(chan struct{})
+	go func() {
+		g.Do(context.Background(), "key", func(ctx context.Context) (i int, e error) {
+			firstStarted.Done()
+			<-firstCh
+			firstFinished.Done()
+			return
+		})
+	}()
+
+	firstStarted.Wait()
+	g.Forget("key") // from this point no two function using same key should be executed concurrently
+
+	var secondStarted int32
+	var secondFinished int32
+	var thirdStarted int32
+
+	secondCh := make(chan struct{})
+	secondRunning := make(chan struct{})
+	go func() {
+		g.Do(context.Background(), "key", func(ctx context.Context) (i int, e error) {
+			atomic.AddInt32(&secondStarted, 1)
+			// Notify that we started
+			secondCh <- struct{}{}
+			// Wait other get above signal
+			<-secondRunning
+			<-secondCh
+			atomic.AddInt32(&secondFinished, 1)
+			return 2, nil
+		})
+	}()
+
+	close(firstCh)
+	firstFinished.Wait() // wait for first execution (which should not affect execution after Forget)
+
+	<-secondCh
+	// Notify second that we got the signal that it started
+	secondRunning <- struct{}{}
+	if atomic.LoadInt32(&secondStarted) != 1 {
+		t.Fatal("Second execution should be executed due to usage of forget")
+	}
+
+	if atomic.LoadInt32(&secondFinished) == 1 {
+		t.Fatal("Second execution should be still active")
+	}
+
+	close(secondCh)
+	result, _, _ := g.Do(context.Background(), "key", func(ctx context.Context) (i int, e error) {
+		atomic.AddInt32(&thirdStarted, 1)
+		return 3, nil
+	})
+
+	if atomic.LoadInt32(&thirdStarted) != 0 {
+		t.Error("Third call should not be started because was started during second execution")
+	}
+	if result != 2 {
+		t.Errorf("We should receive result produced by second call, expected: 2, got %d", result)
+	}
+}
+
 func TestDo_multipleCallsCanceled(t *testing.T) {
 	const n = 5
 


### PR DESCRIPTION
Hey @janos,

I believe your implementation of singleflight is affected by the issue described here:
https://github.com/golang/go/issues/31420.

This issue specifically impacts your implementation because a thread can call `Forget()` after its own context has expired.
I implemented the solution found in this CL:
https://go-review.googlesource.com/c/sync/+/171897.

All existing tests pass successfully, and I also added the test from the CL to ensure that the new behavior is consistent with Google’s implementation.

Note: Before applying the fix, the TestForgetMisbehaving test failed.